### PR TITLE
Use Typography In Header

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -7,7 +7,7 @@ export type HeaderProps = {
       id: string;
       label: string;
       href: string;
-      items: [
+      items?: [
         {
           id: string;
           label: string;
@@ -16,12 +16,13 @@ export type HeaderProps = {
       ];
     },
   ];
+  title: string;
 };
 
-export const Header = ({ navItems }: HeaderProps) => {
+export const Header = ({ navItems, title }: HeaderProps) => {
   return (
     <header>
-      <TitleBar />
+      <TitleBar title={title} />
       <Navbar navItems={navItems} />
     </header>
   );

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -4,10 +4,9 @@ import Container from "@mui/material/Container";
 import Toolbar from "@mui/material/Toolbar";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import ExpandCircleDownOutlinedIcon from "@mui/icons-material/ExpandCircleDownOutlined";
 import Link from "@mui/material/Link";
 import IconButton from "@mui/material/IconButton";
-import Typography from "@mui/material/Typography";
+import { Typography } from "../Typography/Typography";
 import MenuItem from "@mui/material/MenuItem";
 import Menu from "@mui/material/Menu";
 import { Divider } from "@mui/material";
@@ -18,8 +17,9 @@ import Grow from "@mui/material/Grow";
 import Paper from "@mui/material/Paper";
 import Popper from "@mui/material/Popper";
 import MenuList from "@mui/material/MenuList";
+import ChevronDown from "../Icons/ChevronDown";
 
-const Navbar = ({ navItems }: HeaderProps) => {
+const Navbar = ({ navItems }: Omit<HeaderProps, "title">) => {
   const [anchorElNav, setAnchorElNav] = useState<null | HTMLElement>(null);
 
   const [elList, setElList] = useState(
@@ -122,7 +122,7 @@ const Navbar = ({ navItems }: HeaderProps) => {
         <Container maxWidth="xl">
           <Toolbar disableGutters className="pds-wds-navbar-toolbar">
             <div />
-            <Box sx={{ display: { xs: "none", md: "block" } }}>
+            <Box sx={{ display: { xs: "none", sm: "block" } }}>
               {navItems.map((item, index) => {
                 return item.items ? (
                   <>
@@ -131,7 +131,7 @@ const Navbar = ({ navItems }: HeaderProps) => {
                       id="composition-button"
                       aria-haspopup="true"
                       onClick={(e) => handleClick(index, e)}
-                      endIcon={<ExpandCircleDownOutlinedIcon />}
+                      endIcon={<ChevronDown height={10} width={10} />}
                     >
                       {item.label}
                     </Button>
@@ -163,7 +163,7 @@ const Navbar = ({ navItems }: HeaderProps) => {
                                 id="composition-menu"
                                 aria-labelledby="composition-button"
                               >
-                                {item.items.map((subItem) => {
+                                {item.items?.map((subItem) => {
                                   return (
                                     <Link
                                       className="pds-wds-navbar-link"
@@ -173,6 +173,8 @@ const Navbar = ({ navItems }: HeaderProps) => {
                                       <MenuItem className="pds-wds-navbar-menu-item">
                                         <Typography
                                           className="pds-wds-navbar-link-label"
+                                          variant="body2"
+                                          weight="regular"
                                           textAlign="center"
                                         >
                                           {subItem.label}
@@ -201,7 +203,7 @@ const Navbar = ({ navItems }: HeaderProps) => {
               })}
             </Box>
 
-            <Box sx={{ display: { sm: "block", md: "none" } }}>
+            <Box sx={{ display: { xs: "block", sm: "none" } }}>
               <IconButton
                 size="large"
                 aria-label="account of current user"
@@ -210,7 +212,7 @@ const Navbar = ({ navItems }: HeaderProps) => {
                 onClick={handleOpenNavMenu}
                 color="inherit"
               >
-                <ExpandCircleDownOutlinedIcon />
+                <ChevronDown height={10} width={10} />
               </IconButton>
               <Menu
                 id="menu-appbar"
@@ -227,13 +229,19 @@ const Navbar = ({ navItems }: HeaderProps) => {
                 open={Boolean(anchorElNav)}
                 onClose={handleCloseNavMenu}
                 sx={{
-                  display: { xs: "block", md: "none" },
+                  display: { xs: "block", sm: "none" },
                 }}
               >
                 {navItems.map((item) => (
                   <Link key={item.id} href={item.href}>
                     <MenuItem onClick={handleCloseNavMenu}>
-                      <Typography textAlign="center">{item.label}</Typography>
+                      <Typography
+                        variant="body2"
+                        weight="regular"
+                        textAlign="center"
+                      >
+                        {item.label}
+                      </Typography>
                     </MenuItem>
                   </Link>
                 ))}

--- a/src/components/TitleBar/TitleBar.scss
+++ b/src/components/TitleBar/TitleBar.scss
@@ -14,6 +14,11 @@
    color: var(--pds-primary-white);
 }
 
+.pds-wds-titlebar-titlelink{
+   color: white;
+   text-decoration: none;
+}
+
 .pds-wds-titlebar-menu-item:hover {
    background-color: var(--pds-primary-black);
 }
@@ -129,7 +134,7 @@
 
 .pds-wds-titlebar-link-button {   
    font-size: 0.875rem;
-   font-weight: 400;
+   font-weight: bold;
    line-height: 1.1875rem;
    letter-spacing: -0.25px;
    color: var(--pds-primary-white);

--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -7,8 +7,7 @@ import Menu from "@mui/material/Menu";
 import MenuIcon from "@mui/icons-material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import Toolbar from "@mui/material/Toolbar";
-import Typography from "@mui/material/Typography";
-import ExpandCircleDownOutlinedIcon from "@mui/icons-material/ExpandCircleDownOutlined";
+import { Typography } from "../Typography/Typography";
 import Divider from "@mui/material/Divider";
 import InputBase from "@mui/material/InputBase";
 import NasaLogo from "../../assets/nasa.svg";
@@ -21,9 +20,15 @@ import Grow from "@mui/material/Grow";
 import Paper from "@mui/material/Paper";
 import Popper from "@mui/material/Popper";
 import MenuList from "@mui/material/MenuList";
-import { check } from "@nasapds/wds/icons";
+import ArrowCircleDown from "../Icons/ArrowCircleDown";
+import ChevronDown from "../Icons/ChevronDown";
 
 const pages = [
+  {
+    id: "explore-pds",
+    label: "Explore PDS",
+    href: "/",
+  },
   {
     id: "pds-nodes",
     label: "PDS Nodes",
@@ -65,14 +70,13 @@ const pages = [
       },
     ],
   },
-  {
-    id: "explore-pds",
-    label: "Explore PDS",
-    href: "/",
-  },
 ];
 
-const TitleBar = () => {
+export type TitleBarProps = {
+  title: string;
+};
+
+const TitleBar = ({ title }: TitleBarProps) => {
   const [anchorElNav, setAnchorElNav] = useState<null | HTMLElement>(null);
   const [anchorElSubNav, setAnchorElSubNav] = useState<null | Record<
     string,
@@ -185,63 +189,61 @@ const TitleBar = () => {
                 className="pds-wds-titlebar-nasa-logo-md"
                 component="img"
                 sx={{
-                  display: { xs: "none", md: "flex" },
+                  display: { xs: "none", sm: "flex" },
                 }}
                 alt="NASA logo."
                 src={NasaLogo}
               />
             </Link>
-            <Typography
-              className="pds-wds-titlebar-title-lg"
-              variant="h6"
-              noWrap
-              component="a"
-              href="/"
-              sx={{
-                display: { xs: "none", lg: "flex" },
-              }}
+            <Link
+              href="https://www.nasa.gov/"
+              target="_blank"
+              className="pds-wds-titlebar-titlelink"
             >
-              Planetary Data System
-            </Typography>
-            <Typography
-              className="pds-wds-titlebar-title-md"
-              variant="h6"
-              noWrap
-              component="a"
-              href="/"
-              sx={{
-                display: { xs: "none", md: "flex", lg: "none" },
-              }}
-            >
-              Planetary Data System
-            </Typography>
+              <Typography
+                variant="h3"
+                weight="bold"
+                noWrap
+                sx={{
+                  display: { xs: "none", md: "flex" },
+                }}
+              >
+                {title}
+              </Typography>
+            </Link>
+
             <Link href="https://www.nasa.gov/" target="_blank">
               <Box
-                className="pds-wds-titlebar-nasa-logo-xs"
+                className="pds-wds-titlebar-title-md"
                 component="img"
+                sx={{
+                  display: { xs: "flex", sm: "none" },
+                }}
+                alt="NASA logo."
+                src={NasaLogo}
+              />
+            </Link>
+            <Link
+              href="https://www.nasa.gov/"
+              target="_blank"
+              className="pds-wds-titlebar-titlelink"
+            >
+              <Typography
+                className="pds-wds-titlebar-title-xs"
+                variant="h3"
+                weight="bold"
+                noWrap
                 sx={{
                   display: { xs: "flex", md: "none" },
                 }}
-                alt="NASA logo."
-                src={NasaLogo}
-              />
+              >
+                {title}
+              </Typography>
             </Link>
-            <Typography
-              className="pds-wds-titlebar-title-xs"
-              variant="h6"
-              noWrap
-              component="a"
-              href="/"
-              sx={{
-                display: { xs: "flex", md: "none" },
-              }}
-            >
-              Planetary Data System
-            </Typography>
             <Box
               className="pds-wds-titlebar-links"
               sx={{
-                display: { xs: "none", lg: "flex" },
+                display: { xs: "none", sm: "flex" },
               }}
             >
               {pages.map((item, index) => {
@@ -252,7 +254,7 @@ const TitleBar = () => {
                       id="composition-button"
                       aria-haspopup="true"
                       onClick={(e) => handleClick(index, e)}
-                      endIcon={<ExpandCircleDownOutlinedIcon />}
+                      endIcon={<ChevronDown height={10} width={10} />}
                     >
                       {item.label}
                     </Button>
@@ -294,6 +296,8 @@ const TitleBar = () => {
                                       <MenuItem className="pds-wds-titlebar-menu-item">
                                         <Typography
                                           className="pds-wds-titlebar-link-label"
+                                          variant="body2"
+                                          weight="regular"
                                           textAlign="center"
                                         >
                                           {subItem.label}
@@ -313,7 +317,7 @@ const TitleBar = () => {
                   <>
                     <Button
                       className="pds-wds-titlebar-link-button"
-                      endIcon={<ExpandCircleDownOutlinedIcon />}
+                      endIcon={<ArrowCircleDown className="icon" />}
                       key={item.id}
                       id={item.label + "MenuButton"}
                       onClick={(e) => handleOpenSubNavMenu(index, e)}
@@ -359,33 +363,9 @@ const TitleBar = () => {
             <Box
               className="pds-wds-titlebar-links"
               sx={{
-                display: { xs: "none", md: "flex", lg: "none" },
+                display: { xs: "flex", sm: "none" },
               }}
             >
-              <div className="pds-wds-titlebar-search">
-                <div className="pds-wds-titlebar-search-icon-wrapper">
-                  <SearchIcon />
-                </div>
-                <InputBase
-                  className="pds-wds-titlebar-input-base"
-                  placeholder="Search…"
-                  inputProps={{ "aria-label": "search" }}
-                  sx={{
-                    "& .MuiInputBase-input": {
-                      padding: (theme) => theme.spacing(1, 1, 1, 0),
-                      // vertical padding + font size from searchIcon
-                      paddingLeft: (theme) => `calc(1em + ${theme.spacing(4)})`,
-                      transition: (theme) => theme.transitions.create("width"),
-                      '[theme.breakpoints.up("sm")]': {
-                        width: "12ch",
-                        "&:focus": {
-                          width: "20ch",
-                        },
-                      },
-                    },
-                  }}
-                />
-              </div>
               <Divider
                 className="pds-wds-titlebar-link-divider"
                 variant="middle"
@@ -422,7 +402,13 @@ const TitleBar = () => {
               >
                 {pages.map((page) => (
                   <MenuItem key={page.id} onClick={handleCloseNavMenu}>
-                    <Typography textAlign="center">{page.label}</Typography>
+                    <Typography
+                      variant="body2"
+                      weight="regular"
+                      textAlign="center"
+                    >
+                      {page.label}
+                    </Typography>
                   </MenuItem>
                 ))}
               </Menu>
@@ -431,24 +417,9 @@ const TitleBar = () => {
             <Box
               className="pds-wds-titlebar-links"
               sx={{
-                display: { xs: "flex", md: "none" },
+                display: { xs: "flex", sm: "none" },
               }}
             >
-              <IconButton
-                size="large"
-                aria-label="site search"
-                aria-controls="menu-searchbar"
-                aria-haspopup="true"
-                color="inherit"
-              >
-                <SearchIcon />
-              </IconButton>
-              <Divider
-                className="pds-wds-titlebar-link-divider"
-                variant="middle"
-                orientation="vertical"
-                flexItem
-              />
               <IconButton
                 size="large"
                 aria-label="site navigation menu"
@@ -474,12 +445,18 @@ const TitleBar = () => {
                 open={Boolean(anchorElNav)}
                 onClose={handleCloseNavMenu}
                 sx={{
-                  display: { xs: "block", md: "none" },
+                  display: { xs: "block", sm: "none" },
                 }}
               >
                 {pages.map((page) => (
                   <MenuItem key={page.id} onClick={handleCloseNavMenu}>
-                    <Typography textAlign="center">{page.label}</Typography>
+                    <Typography
+                      variant="body2"
+                      weight="regular"
+                      textAlign="center"
+                    >
+                      {page.label}
+                    </Typography>
                   </MenuItem>
                 ))}
               </Menu>

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -66,10 +66,16 @@ export type Props =
   | (NumberProps & Omit<TypographyProps, "variant">);
 
 export const Typography = (props: Props) => {
-  const { variant, weight, ...other } = props;
+  const { variant, weight, className, ...other } = props;
 
-  let typographyClass = "wds-typography";
+  let typographyClass = "";
   let muiVariant;
+
+  if (className) {
+    typographyClass = className + " wds-typography";
+  } else {
+    typographyClass = "wds-typography";
+  }
 
   switch (variant) {
     case "body1":


### PR DESCRIPTION
## 🗒️ Summary
Typography component is now used in the header. Plus various changes listed below:

- Fixed styles being overwritten className prop in Typography.
- Removed anchor typography components. Used link in title.
- Updated titlebar link styles to be bold.
- Use wds icons.
- Title is now required as a prop for header.
- Changed titlebar button requirement to empty list for the "explore pds" link.

## ⚙️ Test Data and/or Report
Follow the steps in the read me to build and run locally https://github.com/NASA-PDS/wds-react/edit/typography/README.md#getting-started. The only difference is in step 1 use branch typography-in-header instead of develop. In summary download the wds and wds-react projects. Build them and then link them, after that build a test project in vite using typescript.

## ♻️ Related Issues
Task is NASA-PDS/portal-wp-tasks/issues/69


