### PR TITLE
Fix Deployment Preview Bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,19 +4,15 @@
     "url": "https://github.com/NASA-PDS/wds-react/issues"
   },
   "description": "Planetary Data System (PDS) React component library",
-  "dependencies": {
-    "@emotion/react": "^11.11.1",
-    "@emotion/styled": "^11.11.0",
-    "@mui/icons-material": "^5.14.3",
-    "@mui/material": "^5.14.4",
-    "classnames": "^2.3.2",
-    "react-router-dom": "^6.26.1"
-  },
   "devDependencies": {
     "@babel/core": "^7.22.9",
     "@babel/preset-env": "^7.22.9",
     "@babel/preset-react": "^7.22.5",
     "@babel/preset-typescript": "^7.22.5",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.14.3",
+    "@mui/material": "^5.14.4",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^25.0.3",
     "@rollup/plugin-image": "^3.0.2",
@@ -45,6 +41,7 @@
     "babel-jest": "^29.6.2",
     "babel-loader": "^9.1.3",
     "babel-plugin-react-require": "^4.0.1",
+    "classnames": "^2.3.2",
     "eslint": "^8.44.0",
     "eslint-config-prettier": "^8.9.0",
     "eslint-plugin-import": "^2.27.5",
@@ -60,6 +57,7 @@
     "prettier": "^3.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.26.1",
     "react-test-renderer": "^18.2.0",
     "rollup": "^3.26.3",
     "rollup-plugin-delete": "^2.0.0",
@@ -72,6 +70,15 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.1",
     "typescript": "^5.1.6"
+  },
+  "peerDependencies": {
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.14.3",
+    "@mui/material": "^5.14.4",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.1"
   },
   "files": [
     "dist",
@@ -108,10 +115,6 @@
     }
   },
   "name": "@nasapds/wds-react",
-  "peerDependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/NASA-PDS/wds-react.git"


### PR DESCRIPTION
## 🗒️ Summary
Fixed a bug where running npm run build -> npm run preview in parent app would throw useState useContext errors in the parent app. The fix involves moving dependencies in wds-react to dev dependencies and peer dependencies.

## ⚙️ Test Data and/or Report
Run as usual in the readme but use this branch along with https://github.com/NASA-PDS/portal-wp/tree/bugs/19-fix-preview branch in portal-wp

## ♻️ Related Issues
https://github.com/NASA-PDS/portal-wp/compare/develop...bugs/19-fix-preview?expand=1
https://github.com/NASA-PDS/portal-wp/issues/19


