### PR TITLE
Allow TitleBar Small Menu Links

### DIFF
--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -746,14 +746,20 @@ const TitleBar = ({
                       </div>
                     ) : (
                       <div className="pds-wds-titlebar-small-menu-link">
-                        <Typography
-                          className="pds-wds-titlebar-link-label"
-                          variant="h4"
-                          weight="semibold"
-                          textAlign="left"
+                        <Link
+                          className="pds-wds-titlebar-link"
+                          key={item.id}
+                          href={item.href}
                         >
-                          {item.label}
-                        </Typography>
+                          <Typography
+                            className="pds-wds-titlebar-link-label"
+                            variant="h4"
+                            weight="semibold"
+                            textAlign="left"
+                          >
+                            {item.label}
+                          </Typography>
+                        </Link>
                       </div>
                     );
                   })}


### PR DESCRIPTION
## 🗒️ Summary
Single items on the small menu are now clickable. This is support for https://github.com/NASA-PDS/portal-wp/pull/34 on responsive sizes.

## ⚙️ Test Data and/or Report
Run with https://github.com/NASA-PDS/portal-wp/pull/34 click the "feedback" or any other single item.

## ♻️ Related Issues
- refs https://github.com/NASA-PDS/portal-wp/pull/34

