### PR TITLE
Features/featured link updates for collections

### DIFF
--- a/src/components/FeaturedLink/FeaturedLink.tsx
+++ b/src/components/FeaturedLink/FeaturedLink.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { IconArrowCircleDown, IconArrowCircleRight, IconArrowRight } from '../Icons';
+import { IconArrowCircleDown, IconArrowCircleRight, IconArrowDiagonal, IconArrowRight } from '../Icons';
 import { Typography } from '../Typography';
 import Box from '@mui/material/Box';
 import Divider from '@mui/material/Divider';
@@ -32,6 +32,7 @@ export type FeaturedLinkProps = {
   description:string;
   primaryLink:string;
   primaryLinkLabel?:string;
+  primaryLinkType?:"internal" | "external"
   startExpanded?:boolean;
   title:string;
 }
@@ -42,6 +43,7 @@ export const FeaturedLink = ({
   description,
   primaryLink,
   primaryLinkLabel,
+  primaryLinkType = "internal",
   startExpanded = false,
   title,
 }:FeaturedLinkProps) => {
@@ -67,7 +69,7 @@ export const FeaturedLink = ({
               </IconButton>
             </Box>
             <Stack sx={{padding: "10px"}}>
-              <Link to={primaryLink}>
+              <Link to={primaryLink} target={ primaryLinkType === "internal" ? "_self" : "_blank"}>
                 <Typography variant='h6' weight='semibold' sx={{margin: "5px"}}>{title}</Typography>
               </Link>
               <Typography variant='body4' weight='regular' sx={{margin: "5px", }}>{ellipsisText(description, 256)}</Typography>
@@ -91,7 +93,7 @@ export const FeaturedLink = ({
           columns === undefined && <Grid mdOffset={1} />
         }
         <Grid xs={2} display={"flex"} justifyContent={"right"} alignItems={"center"}>
-          <Link to={primaryLink}>
+          <Link to={primaryLink} target={ primaryLinkType === "internal" ? "_self" : "_blank"}>
             <Stack direction="row" alignItems={"center"} gap={1}>
               { primaryLinkLabel && <Typography variant="h4" weight="semibold" display={{xs: "none", md:"block"}}>{primaryLinkLabel}</Typography> }
               <IconButton aria-label="arrow" sx={{
@@ -103,7 +105,7 @@ export const FeaturedLink = ({
                 height: "36px",
                 width: "36px",
               }}>
-                <IconArrowRight />
+                { primaryLinkType === "internal" ? <IconArrowRight /> : <IconArrowDiagonal /> }
               </IconButton>
             </Stack>
           </Link>

--- a/src/components/FeaturedLinkDetails/FeaturedLinkDetails.tsx
+++ b/src/components/FeaturedLinkDetails/FeaturedLinkDetails.tsx
@@ -243,9 +243,9 @@ export const FeaturedLinkDetails = (props:FeaturedLinkDetailsProps) => {
           props.variant === FeaturedLinkDetailsVariant.DATA_BUNDLE && <>
             <DetailRow label={"Investigation"} value={props.investigation.value} link={props.investigation.link} />
             <DetailRow label={"Identifier"} value={props.lid.value} link={props.lid.link} />
-            <DetailRow label={"Discipline Name"} value={props.disciplineName.join(",")}/>
+            <DetailRow label={"Discipline Name"} value={props.disciplineName.join(", ")}/>
             <DetailRow label={"DOI"} value={props.doi.value} link={props.doi.link} />
-            <DetailRow label={"Processing Level"} value={props.processingLevel.join(",")} />
+            <DetailRow label={"Processing Level"} value={props.processingLevel.join(", ")} />
             <DetailRow label={"Start Date"} value={props.startDate.value} link={props.startDate.link}/>
             <DetailRow label={"Stop Date"} value={props.stopDate.value} link={props.startDate.link}/>
           </>
@@ -254,9 +254,9 @@ export const FeaturedLinkDetails = (props:FeaturedLinkDetailsProps) => {
           props.variant === FeaturedLinkDetailsVariant.DATA_COLLECTION && <>
             <DetailRow label={"Investigation"} value={props.investigation.value} link={props.investigation.link} />
             <DetailRow label={"Identifier"} value={props.lid.value} link={props.lid.link} />
-            <DetailRow label={"Discipline Name"} value={props.disciplineName.join(",")} />
+            <DetailRow label={"Discipline Name"} value={props.disciplineName.join(", ")} />
             <DetailRow label={"DOI"} value={props.doi.value} link={props.doi.link} />
-            <DetailRow label={"Processing Level"} value={props.processingLevel.join(",")} />
+            <DetailRow label={"Processing Level"} value={props.processingLevel.join(", ")} />
             <DetailRow label={"Start Date"} value={props.startDate.value}  link={props.startDate.link}/>
             <DetailRow label={"Stop Date"} value={props.stopDate.value}  link={props.stopDate.link}/>
           </>
@@ -305,18 +305,18 @@ export const FeaturedLinkDetails = (props:FeaturedLinkDetailsProps) => {
         {
           props.variant === FeaturedLinkDetailsVariant.DATA_SET && <>
             <DetailRow label={"Investigation"} value={props.investigation.value} link={props.investigation.link} />
-            <DetailRow label={"Discipline Name"} value={props.disciplineName.join(",")} />
+            <DetailRow label={"Discipline Name"} value={props.disciplineName.join(", ")} />
             <DetailRow label={"DOI"} value={props.doi.value} link={props.doi.link} />
-            <DetailRow label={"Processing Level"} value={props.processingLevel.join(",")} />
+            <DetailRow label={"Processing Level"} value={props.processingLevel.join(", ")} />
             <DetailRow label={"Target"} value={props.target.value} link={props.target.link}/>
           </>
         }
         {
           props.variant === FeaturedLinkDetailsVariant.FACILITY && <>
             <DetailRow label={"Identifier"} value={props.lid.value} link={props.lid.link} />
-            <DetailRow label={"Type"} value={props.type.join(",")} />
-            <DetailRow label={"Country"} value={props.country.join(",")} />
-            <DetailRow label={"Telescopes"} value={props.telescopes.join(",")} />
+            <DetailRow label={"Type"} value={props.type.join(", ")} />
+            <DetailRow label={"Country"} value={props.country.join(", ")} />
+            <DetailRow label={"Telescopes"} value={props.telescopes.join(", ")} />
           </>
         }
         {
@@ -329,7 +329,7 @@ export const FeaturedLinkDetails = (props:FeaturedLinkDetailsProps) => {
           props.variant === FeaturedLinkDetailsVariant.INSTRUMENT_HOST && <>
             <DetailRow label={"Identifier"} value={props.lid.value} link={props.lid.link} />
             <DetailRow label={"Investigation"} value={props.investigation.value} link={props.investigation.link} />
-            <DetailRow label={"Instruments"} value={props.instruments.join(",")} />
+            <DetailRow label={"Instruments"} value={props.instruments.join(", ")} />
           </>
         }
         {
@@ -359,7 +359,7 @@ export const FeaturedLinkDetails = (props:FeaturedLinkDetailsProps) => {
           props.variant === FeaturedLinkDetailsVariant.TELESCOPE && <>
             <DetailRow label={"Identifier"} value={props.lid.value} link={props.lid.link} />
             <DetailRow label={"Instruments"} value={props.instruments.join(", ")} />
-            <DetailRow label={"Facility"} value={props.facility.join(",")} />
+            <DetailRow label={"Facility"} value={props.facility.join(", ")} />
           </>
         }
         {
@@ -367,7 +367,7 @@ export const FeaturedLinkDetails = (props:FeaturedLinkDetailsProps) => {
             <DetailRow label={"URL"} value={props.url.value} link={props.url.link} />
             <DetailRow label={"Support"} value={props.support.value} link={props.support.link}/>
             <DetailRow label={"Version"} value={props.version.value} link={props.version.link}/>
-            <DetailRow label={"Category"} value={props.categories.join(",")} />
+            <DetailRow label={"Category"} value={props.categories.join(", ")} />
           </>
         }
         {

--- a/src/components/FeaturedLinkDetails/FeaturedLinkDetails.tsx
+++ b/src/components/FeaturedLinkDetails/FeaturedLinkDetails.tsx
@@ -79,9 +79,9 @@ const DetailRow = (props:DetailRowProps) => {
 };
 
 export enum FeaturedLinkDetailsVariant {
-  BUNDLE_LIST = "bundle-list",
   DATA_BUNDLE = "data-bundle",
   DATA_COLLECTION = "data-collection",
+  DATA_COLLECTION_LIST = "collection-list",
   DATA_SET = "data-set",
   FACILITY = "facility",
   INSTRUMENT = "instrument",
@@ -102,16 +102,22 @@ type FeaturedLinkDetailsBaseProps = {
   tags?:Array<string>;
 };
 
-export type FeaturedLinkBundleListDetailProps = FeaturedLinkDetailsBaseProps & {
-  bundleGroups:Array<{
-    title: "Calibrated Data Products" | "Derived Data Products" | "Partially Processed Data Products" | "Raw Data Products" | "Telemetry Data Products",
-    items:Array<{
-      title:string,
-      description:string,
-      link:string
-    }>
-  }>;
-  variant:FeaturedLinkDetailsVariant.BUNDLE_LIST;
+export enum DATA_COLLECTION_GROUP_TITLE {
+  CALIBRATED = "Calibrated Data Products",
+  DERIVED = "Derived Data Products",
+  PARTIALLY_PROCESSED = "Partially Processed Data Products",
+  RAW = "Raw Data Products",
+  TELEMETRY = "Telemetry Data Products",
+  UNKNOWN = "Unknown Processing Level"
+};
+
+export type DataCollectionGroup = {
+  title:DATA_COLLECTION_GROUP_TITLE,
+  items:Array<{
+    title:string,
+    description:string,
+    link:string | undefined
+  }>
 }
 
 export type FeaturedLinkDataBundleDetailsProps = FeaturedLinkDetailsBaseProps & {
@@ -134,6 +140,11 @@ export type FeaturedLinkDataCollectionDetailsProps = FeaturedLinkDetailsBaseProp
   startDate:FeaturedLinkDetailData;
   stopDate:FeaturedLinkDetailData;
   variant:FeaturedLinkDetailsVariant.DATA_COLLECTION;
+}
+
+export type FeaturedLinkDataCollectionListDetailProps = FeaturedLinkDetailsBaseProps & {
+  collectionGroups:Array<DataCollectionGroup>;
+  variant:FeaturedLinkDetailsVariant.DATA_COLLECTION_LIST;
 }
 
 export type FeaturedLinkDataSetDetailsProps = FeaturedLinkDetailsBaseProps & {
@@ -166,7 +177,6 @@ export type FeaturedLinkInstrumentHostDetailsProps =
     lid: FeaturedLinkDetailData;
     variant: FeaturedLinkDetailsVariant.INSTRUMENT_HOST;
 };
-
 
 export type FeaturedLinkInvestigationDetailsProps = FeaturedLinkDetailsBaseProps & {
   instrumentHostTitles:Array<string>;
@@ -207,9 +217,9 @@ export type FeaturedLinkToolDetailsProps = FeaturedLinkDetailsBaseProps & {
 }
 
 export type FeaturedLinkDetailsProps = (
-  FeaturedLinkBundleListDetailProps
-  | FeaturedLinkDataBundleDetailsProps 
+  FeaturedLinkDataBundleDetailsProps 
   | FeaturedLinkDataCollectionDetailsProps
+  | FeaturedLinkDataCollectionListDetailProps
   | FeaturedLinkDataSetDetailsProps
   | FeaturedLinkFacilityDetailsProps
   | FeaturedLinkInstrumentDetailsProps 
@@ -230,35 +240,6 @@ export const FeaturedLinkDetails = (props:FeaturedLinkDetailsProps) => {
     }}>
       <Stack spacing={"5px"}>
         {
-          props.variant === FeaturedLinkDetailsVariant.BUNDLE_LIST && <>
-            {
-              <Stack gap={"20px"}>
-                {
-                props.bundleGroups.map( (group, bundleIndex) => {
-                  return (
-                    <Stack key={bundleIndex} gap={"12px"}>
-                      <Typography variant="h6" weight="semibold">{group.title}</Typography>
-                      {
-                        group.items.map( (item, itemIndex) => {
-                          return (
-                            <Stack direction={"column"} gap={"8px"} key={itemIndex}>
-                              <Link to={item.link}>
-                                <Typography variant="body5" weight="regular">{item.title}</Typography>
-                              </Link>
-                              <Typography variant="body5" weight="regular" sx={{paddingLeft: "32px"}}>{item.description}</Typography>
-                            </Stack>
-                          )
-                        })
-                      }
-                    </Stack>
-                  );
-                })
-                }
-              </Stack>
-            }
-          </>
-        }
-        {
           props.variant === FeaturedLinkDetailsVariant.DATA_BUNDLE && <>
             <DetailRow label={"Investigation"} value={props.investigation.value} link={props.investigation.link} />
             <DetailRow label={"Identifier"} value={props.lid.value} link={props.lid.link} />
@@ -278,6 +259,47 @@ export const FeaturedLinkDetails = (props:FeaturedLinkDetailsProps) => {
             <DetailRow label={"Processing Level"} value={props.processingLevel.join(",")} />
             <DetailRow label={"Start Date"} value={props.startDate.value}  link={props.startDate.link}/>
             <DetailRow label={"Stop Date"} value={props.stopDate.value}  link={props.stopDate.link}/>
+          </>
+        }
+        {
+          props.variant === FeaturedLinkDetailsVariant.DATA_COLLECTION_LIST && <>
+            {
+              <Stack gap={"20px"}>
+                {
+                  props.collectionGroups && props.collectionGroups.map( (group, collectionIndex) => {
+                    return (
+                      <Stack key={collectionIndex} gap={"12px"}>
+                        <Typography variant="h6" weight="semibold">{group.title}</Typography>
+                        {
+                          group.items.map( (item, itemIndex) => {
+                            return (
+                              <Stack direction={"column"} gap={"8px"} key={itemIndex}>
+                                {
+                                  item.link && <>
+                                    <Link to={item.link} style={{color: "#1C67E3", textDecoration: "underline"}}>
+                                      <Typography variant="body5" weight="regular">{item.title}</Typography>
+                                    </Link>
+                                  </>
+                                }
+                                {
+                                  !item.link && <Typography variant="body5" weight="regular">{item.title}</Typography>
+                                }
+                                <Typography variant="body5" weight="regular" sx={{paddingLeft: "32px"}}>{item.description}</Typography>
+                              </Stack>
+                            )
+                          })
+                        }
+                      </Stack>
+                    );
+                  })
+                }
+                {
+                  (!props.collectionGroups || props.collectionGroups.length === 0) && <>
+                    <Typography variant="body5" weight="regular">No Collections Found.</Typography>
+                  </>
+                }
+              </Stack>
+            }
           </>
         }
         {

--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -221,7 +221,6 @@ const TitleBar = ({
             </Link>
             <Link
               href={titleLink}
-              target="_blank"
               className="pds-wds-titlebar-titlelink"
             >
               <Typography
@@ -377,7 +376,6 @@ const TitleBar = ({
             </Link>
             <Link
               href={titleLink}
-              target="_blank"
               className="pds-wds-titlebar-titlelink"
             >
               <Typography
@@ -453,7 +451,6 @@ const TitleBar = ({
             </Link>
             <Link
               href={titleLink}
-              target="_blank"
               className="pds-wds-titlebar-titlelink"
             >
               <Typography
@@ -525,7 +522,6 @@ const TitleBar = ({
                         </Link>
                         <Link
                           href={titleLink}
-                          target="_blank"
                           className="pds-wds-titlebar-titlelink"
                         >
                           <Typography
@@ -574,7 +570,6 @@ const TitleBar = ({
                         </Link>
                         <Link
                           href={titleLink}
-                          target="_blank"
                           className="pds-wds-titlebar-titlelink"
                         >
                           <Typography


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

This PR addresses:

1. Updates to components in support of displaying collection details in the portal
2. Link behavior when clicking the title link in the titlebar
3. Updated FeaturedLink component so that the icon can be changed depending on if the link is external to the site, clicking the link if set to "external" also opens the link in a new window or tab.
4. Fixed join operations in FeaturedLinkDetails so that a space is added after a comma to improve readability of concatenated strings.

## ⚙️ Test Data and/or Report

Tested build locally and ensured that `npm run build` does not generate errors.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

Related to NASA-PDS/portal-wp#45