### PR TITLE
Updated node version used by publish-to-npm.yml GitHub workflow to resolve build error.

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: npm
-          node-version: 'lts/*'
+          node-version: 'lts/iron'
           registry-url: 'https://registry.npmjs.org'
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

The `npm run build-lib` command in the publish to npm workflow fails when using the latest lts release of node which is `jod`.  To fix this, I had to set the node version to be `lts/iron`.

## ⚙️ Test Data and/or Report

Was able to reproduce the error locally when using `lts/jod`, and verified that using `lts/iron` does not generate the error.

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

#85 
