### PR TITLE
Bumped @nasapds/wds package to version 0.0.5.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@nasapds/wds": "^0.0.4"
+        "@nasapds/wds": "^0.0.5"
       },
       "devDependencies": {
         "@babel/core": "^7.22.9",
@@ -3764,9 +3764,9 @@
       "dev": true
     },
     "node_modules/@nasapds/wds": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@nasapds/wds/-/wds-0.0.4.tgz",
-      "integrity": "sha512-aXD0hGqcRzOG/T8qmkhXsiFH/QHd2KZu3qFYPlIRm4Vjueredx/Zj4aOrvFFJHjkSakgvVCSEoFLutkr6P37Fg==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@nasapds/wds/-/wds-0.0.5.tgz",
+      "integrity": "sha512-dQbJ5cQPqkkRd9BARlEb7E0PkGu2Uiq9rj3DlPZXb7e6vTJZ9G/mJNBbXXV0PKMDuEvdImjwHPcE3rTp+n8UTA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@fontsource-variable/inter": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "definition": "dist/esm/index.d.ts"
   },
   "types": "./dist/esm/index.d.ts",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "dependencies": {
     "@nasapds/wds": "^0.0.5"
   }

--- a/package.json
+++ b/package.json
@@ -135,6 +135,6 @@
   "types": "./dist/esm/index.d.ts",
   "version": "0.0.5",
   "dependencies": {
-    "@nasapds/wds": "^0.0.4"
+    "@nasapds/wds": "^0.0.5"
   }
 }


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary

This PR addresses the need to bump our `@nasapds/wds` version to `0.0.5` and bump the version number of `wds-react` to `0.0.6`.

## ⚙️ Test Data and/or Report

Tested locally and verified that the `build-lib` and `build-icons` commands do not generate errors.
